### PR TITLE
use ReallyUserFriendlyTypes vocab for type selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.mo
+collective.vaporisation.egg-info/

--- a/collective/vaporisation/adapter.py
+++ b/collective/vaporisation/adapter.py
@@ -6,7 +6,6 @@ from zope.component import adapts
 from zope.interface import implements
 from Products.CMFCore.utils import getToolByName
 from interfaces import ISteamer, IVaporizedCloud
-from Acquisition import aq_inner
 
 
 class Steamer(object):
@@ -15,18 +14,31 @@ class Steamer(object):
     implements(ISteamer)
 
     def __init__(self, context):
-        self.context = aq_inner(context)
-        self.base_query = {}
+        self.context = context
+
+    # Properties
+    # Initialize them as property methods, as on __init__ time, context might
+    # be a PseudoAssignment, from which no plone_utils can be fetched.
+
+    @property
+    def base_query(self):
+        return {}
+
+    @property
+    def encoding(self):
         putils = getToolByName(self.context, 'plone_utils')
+        return putils.getSiteEncoding()
+
+    @property
+    def search_path(self):
         purl = getToolByName(self.context, 'portal_url')
-        self.encoding = putils.getSiteEncoding()
 
         root_path= ('/').join(purl.getPortalObject().getPhysicalPath())
         if self.context.data.startpath:
             search_path= root_path+self.context.data.startpath
         else:
             search_path= root_path
-        self.search_path = search_path
+        return search_path
 
 
     def getStepForTag(self, tag):

--- a/collective/vaporisation/adapter.py
+++ b/collective/vaporisation/adapter.py
@@ -6,6 +6,7 @@ from zope.component import adapts
 from zope.interface import implements
 from Products.CMFCore.utils import getToolByName
 from interfaces import ISteamer, IVaporizedCloud
+from Acquisition import aq_inner
 
 
 class Steamer(object):
@@ -14,7 +15,7 @@ class Steamer(object):
     implements(ISteamer)
 
     def __init__(self, context):
-        self.context = context
+        self.context = aq_inner(context)
         self.base_query = {}
         putils = getToolByName(self.context, 'plone_utils')
         purl = getToolByName(self.context, 'portal_url')

--- a/collective/vaporisation/adapter.py
+++ b/collective/vaporisation/adapter.py
@@ -1,35 +1,13 @@
+"""
+Adapters for the tagcloud
+"""
+
 # -*- coding: utf-8 -*-
 from random import shuffle
-from zope.component import adapts
+from zope.component import adapts, getSiteManager
 from zope.interface import implements
 from Products.CMFCore.utils import getToolByName
-from .interfaces import ISteamer, IVaporizedCloud, ISearchLinkbase
-
-
-class SearchLinkbase(object):
-    """Default adapter to retrieve a base url for a calendar view.
-    In this default implementation we use the @@event_listing view as calendar
-    view.
-
-    For method documentation, see interfaces.py.
-    """
-    implements(ISearchLinkbase)
-
-    def __init__(self, context):
-        self.context = context
-        self.urlpart = "cloud_search"
-
-    def removable_base_url(self):
-        ret = "%s/%s" % (self.context.absolute_url(), self.urlpart)
-        return ret
-
-    def linkpath_base_url(self):
-        portal = getToolByName(self.context, 'portal_url').getPortalObject()
-        ret = "%s/cloud_search" % portal.absolute_url()
-        return ret
-
-    def portlet_base_url(self):
-        return self.linkpath_base_url
+from interfaces import ISteamer, IVaporizedCloud
 
 
 class Steamer(object):

--- a/collective/vaporisation/adapter.py
+++ b/collective/vaporisation/adapter.py
@@ -1,13 +1,35 @@
-"""
-Adapters for the tagcloud
-"""
-
 # -*- coding: utf-8 -*-
 from random import shuffle
-from zope.component import adapts, getSiteManager
+from zope.component import adapts
 from zope.interface import implements
 from Products.CMFCore.utils import getToolByName
-from interfaces import ISteamer, IVaporizedCloud
+from .interfaces import ISteamer, IVaporizedCloud, ISearchLinkbase
+
+
+class SearchLinkbase(object):
+    """Default adapter to retrieve a base url for a calendar view.
+    In this default implementation we use the @@event_listing view as calendar
+    view.
+
+    For method documentation, see interfaces.py.
+    """
+    implements(ISearchLinkbase)
+
+    def __init__(self, context):
+        self.context = context
+        self.urlpart = "cloud_search"
+
+    def removable_base_url(self):
+        ret = "%s/%s" % (self.context.absolute_url(), self.urlpart)
+        return ret
+
+    def linkpath_base_url(self):
+        portal = getToolByName(self.context, 'portal_url').getPortalObject()
+        ret = "%s/cloud_search" % portal.absolute_url()
+        return ret
+
+    def portlet_base_url(self):
+        return self.linkpath_base_url
 
 
 class Steamer(object):

--- a/collective/vaporisation/adapter.py
+++ b/collective/vaporisation/adapter.py
@@ -17,6 +17,7 @@ class Steamer(object):
 
     def __init__(self, context):
         self.context = context
+        self.base_query = {}
 
     def getStepForTag(self, tag):
         """ Only used for display purposes """
@@ -153,13 +154,14 @@ class Steamer(object):
         # Then we transform the keywords into unicode objects
         # And we keep an untouched list of keywords (for the form vocabulary)
         for index in self.context.indexes_to_use:
-            control_query={'path':search_path}
+            control_query={'path': search_path}
             if self.context.type:
-                control_query['portal_type']=self.context.type
+                control_query['portal_type'] = self.context.type
+            control_query.update(self.base_query)
 
-            subjects = [x for x
-                        in catalog.uniqueValuesFor(index)
-                        if catalog.searchResults(index=x, **control_query)]
+            idxs = catalog.uniqueValuesFor(index)
+            subjects = [idx for idx in idxs
+                        if catalog.searchResults(index=idx, **control_query)]
             self.context.all_keys = [unicode(k, encoding) for k in subjects]
             self.context.all_keys.sort()
             self.context.keywords = [k for k in self.context.all_keys]
@@ -173,7 +175,8 @@ class Steamer(object):
             else:
                 keywords = [k.encode(encoding) for k in self.context.keywords
                                 if k not in self.context.restrict]
-            query = control_query.copy()
+            query = {}
+            query.update(control_query)
             query['index'] = keywords
             objects  = catalog(**query)
             keywords = set(keywords)

--- a/collective/vaporisation/configure.zcml
+++ b/collective/vaporisation/configure.zcml
@@ -6,13 +6,13 @@
     i18n_domain="collective.vaporisation">
 
   <five:registerPackage package="." />
-  
+
   <i18n:registerTranslations directory="locales" />
 
   <!-- Include the sub-packages that use their own configure.zcml files. -->
   <include package=".browser" />
   <include package=".portlets" />
-  
+
   <!-- Register the installation GenericSetup extension profile -->
   <genericsetup:registerProfile
       name="default"
@@ -21,23 +21,23 @@
       description=""
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
-	
+
   <subscriber
 	 for=".interfaces.IVaporizedCloud
 	      .interfaces.ITreeUpdateEvent"
 	 handler=".events.UpdateTreeOnCloudChanges"
 	 />
-	 
+
   <utility
 	 name="collective.vaporisation.keywords"
 	 component=".vocabularies.KeywordVocabularyFactory"
 	 />
-	 
+
   <utility
 	 name="collective.vaporisation.indexes"
 	 component=".vocabularies.IndexesVocabularyFactory"
 	 />
-	 
+
   <utility
 	 name="collective.vaporisation.use_mode"
 	 component=".vocabularies.ModeVocabularyFactory"
@@ -47,6 +47,11 @@
            provides = ".interfaces.ISteamer"
            factory  = ".adapter.Steamer"
            name = "default"
-           />	 
+           />
+
+  <adapter
+      for="zope.interface.Interface"
+      factory=".adapter.SearchLinkbase"
+      />
 
 </configure>

--- a/collective/vaporisation/configure.zcml
+++ b/collective/vaporisation/configure.zcml
@@ -6,13 +6,13 @@
     i18n_domain="collective.vaporisation">
 
   <five:registerPackage package="." />
-
+  
   <i18n:registerTranslations directory="locales" />
 
   <!-- Include the sub-packages that use their own configure.zcml files. -->
   <include package=".browser" />
   <include package=".portlets" />
-
+  
   <!-- Register the installation GenericSetup extension profile -->
   <genericsetup:registerProfile
       name="default"
@@ -21,23 +21,23 @@
       description=""
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
-
+	
   <subscriber
 	 for=".interfaces.IVaporizedCloud
 	      .interfaces.ITreeUpdateEvent"
 	 handler=".events.UpdateTreeOnCloudChanges"
 	 />
-
+	 
   <utility
 	 name="collective.vaporisation.keywords"
 	 component=".vocabularies.KeywordVocabularyFactory"
 	 />
-
+	 
   <utility
 	 name="collective.vaporisation.indexes"
 	 component=".vocabularies.IndexesVocabularyFactory"
 	 />
-
+	 
   <utility
 	 name="collective.vaporisation.use_mode"
 	 component=".vocabularies.ModeVocabularyFactory"
@@ -47,11 +47,6 @@
            provides = ".interfaces.ISteamer"
            factory  = ".adapter.Steamer"
            name = "default"
-           />
-
-  <adapter
-      for="zope.interface.Interface"
-      factory=".adapter.SearchLinkbase"
-      />
+           />	 
 
 </configure>

--- a/collective/vaporisation/configure.zcml
+++ b/collective/vaporisation/configure.zcml
@@ -39,11 +39,6 @@
 	 />
 	 
   <utility
-	 name="collective.vaporisation.types"
-	 component=".vocabularies.TypesVocabularyFactory"
-	 />
-	 
-  <utility
 	 name="collective.vaporisation.use_mode"
 	 component=".vocabularies.ModeVocabularyFactory"
 	 />

--- a/collective/vaporisation/interfaces.py
+++ b/collective/vaporisation/interfaces.py
@@ -63,7 +63,7 @@ class ICustomizableCloud(IPortletDataProvider):
     type = Tuple(
         title=_(u"Type of contents"),
         description=_(u"Only the objects of this type will be counted."),
-        value_type=Choice(vocabulary='collective.vaporisation.types'),
+        value_type=Choice(vocabulary='plone.app.vocabularies.ReallyUserFriendlyTypes'),
         required=False,
         )
 

--- a/collective/vaporisation/interfaces.py
+++ b/collective/vaporisation/interfaces.py
@@ -10,6 +10,11 @@ from zope.schema import Int, List, Dict, Choice, Bool, Tuple, TextLine
 _ = MessageFactory('collective.vaporisation')
 
 
+class ISearchLinkbase(Interface):
+    def get_base_url():
+        """Get base url to search form.
+        """
+
 class ITreeUpdateEvent(IObjectModifiedEvent):
     """This triggers the rebuilding of the whole tree
     """

--- a/collective/vaporisation/interfaces.py
+++ b/collective/vaporisation/interfaces.py
@@ -10,11 +10,6 @@ from zope.schema import Int, List, Dict, Choice, Bool, Tuple, TextLine
 _ = MessageFactory('collective.vaporisation')
 
 
-class ISearchLinkbase(Interface):
-    def get_base_url():
-        """Get base url to search form.
-        """
-
 class ITreeUpdateEvent(IObjectModifiedEvent):
     """This triggers the rebuilding of the whole tree
     """

--- a/collective/vaporisation/interfaces.py
+++ b/collective/vaporisation/interfaces.py
@@ -1,24 +1,22 @@
 # -*- coding: utf-8 -*-
-
-from zope.schema import Int, List, Dict, Choice, Bool, Tuple, TextLine
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
-from zope.interface import Interface
-from zope.i18nmessageid import MessageFactory
 from plone.app.vocabularies.catalog import SearchableTextSourceBinder
 from plone.portlets.interfaces import IPortletDataProvider
+from zope.i18nmessageid import MessageFactory
+from zope.interface import Interface
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.schema import Int, List, Dict, Choice, Bool, Tuple, TextLine
 
 
 _ = MessageFactory('collective.vaporisation')
 
 
-class ITreeUpdateEvent( IObjectModifiedEvent ):
-    """
-    This triggers the rebuilding of the whole tree
+class ITreeUpdateEvent(IObjectModifiedEvent):
+    """This triggers the rebuilding of the whole tree
     """
 
-class ICustomizableCloud( IPortletDataProvider ):
-    """
-    Customizable parts of the cloud
+
+class ICustomizableCloud(IPortletDataProvider):
+    """Customizable parts of the cloud
     """
     # Customization
     name = TextLine(
@@ -27,7 +25,7 @@ class ICustomizableCloud( IPortletDataProvider ):
         required=True,
         default=u"Tagcloud"
         )
-    
+
     steps = Int(
         title=_(u"Number of different sizes"),
         description=_(u"This number will also determine the biggest size."),
@@ -41,31 +39,34 @@ class ICustomizableCloud( IPortletDataProvider ):
         required=False,
         default=0
         )
-    
+
     timeout = Int(title=_(u'Cloud reload timeout'),
-        description=_(u'Time in minutes after which the cloud should be reloaded.'),
+        description=_(u'Time in minutes after which the cloud should be '
+                      u'reloaded.'),
         required=True,
         default=100)
-    
+
     startpath = Choice(title=_(u"Start path"),
-                       description=_(u"Only the objects under this directory will be counted. If empty, the portlet will search in all the site."),
-                       required=False,
-                       source=SearchableTextSourceBinder({}, default_query='path:'))
-    
+        description=_(u'Only the objects under this directory will be counted.'
+                      u' If empty, the portlet will search in all the site.'),
+        required=False,
+        source=SearchableTextSourceBinder({}, default_query='path:'))
+
     indexes_to_use = Tuple(
          title=_(u"Indexes to use"),
-         description=_(u"Select from the list the indexes to use for the cloud"),
+         description=_(u"Select from the list the indexes to use for the "
+                       u"cloud"),
          default=('Subject',),
          value_type=Choice(vocabulary='collective.vaporisation.indexes'),
          required=True)
-    
+
     type = Tuple(
         title=_(u"Type of contents"),
         description=_(u"Only the objects of this type will be counted."),
         value_type=Choice(vocabulary='collective.vaporisation.types'),
         required=False,
         )
-    
+
     joint = Bool(
         default=False,
         required=False,
@@ -73,7 +74,7 @@ class ICustomizableCloud( IPortletDataProvider ):
         description=_(u"Joint navigation puts keywords together"
                       u" for associative searches.")
         )
-    
+
     white_list = Tuple(
         required=False,
         title=_(u"Use only the keywords of this list"),
@@ -84,32 +85,34 @@ class ICustomizableCloud( IPortletDataProvider ):
     restrict = Tuple(
         required=False,
         title=_(u"Remove from keywords list"),
-        description=_(u"Restrict the cloud keywords by removing these keywords."
+        description=_(u"Restrict the cloud keywords by removing these "
+                      u"keywords."
                       u"If there is something selected in the list over,"
                       u" the values of that list will be ignored."),
         value_type=Choice(vocabulary='collective.vaporisation.keywords'),
         )
-    
+
     mode_to_use = Choice(
         title=_(u"Mode to use"),
         description=_(u'Select one of the possible mode to use the cloud'),
-        vocabulary= 'collective.vaporisation.use_mode',
+        vocabulary='collective.vaporisation.use_mode',
         required=True,
         default=('default',),
         )
-    
+
     sort = Bool(
         default=True,
         required=False,
         title=_(u"Sort keywords"),
-        description=_(u"If selected, the keywords will be sorted alphabetically.")
+        description=_(u"If selected, the keywords will be sorted "
+                      u"alphabetically.")
         )
-    
+
+
 class IVaporizedCloud(ICustomizableCloud):
+    """A cloudy bunch of keywords
     """
-    A cloudy bunch of keywords
-    """
-    
+
     # storing the tags
     keywords = List(title=u"The list of keywords", default=[])
     all_keys = List(title=u"The list of all the keywords", default=[])
@@ -119,7 +122,7 @@ class IVaporizedCloud(ICustomizableCloud):
     lowest  = Int(title=u"lowest weight", default=10)
     highest = Int(title=u"heighest weight", default=20)
 
-    
+
 class ISteamer(Interface):
     """
     The steamer releases the pression by letting the steam out.
@@ -136,7 +139,7 @@ class ISteamer(Interface):
         If the occurence of the tags is even, they will all be displayed
         at 100%
         """
-    
+
     def getTagsFromTree(self, keywords):
         """
         This method returns a list of dict.
@@ -186,7 +189,7 @@ class ISteamer(Interface):
         the already filled tree. It's not very optimal, but
         it is done only once.
         """
-        
+
     def setTree(self):
         """
         Using the catalog, this method creates a blank tree.
@@ -195,19 +198,19 @@ class ISteamer(Interface):
         properties, such as number of occurences.
         Keywords are stored as unicodes.
         """
- 
 
-class ICloudRenderer( Interface ):
+
+class ICloudRenderer(Interface):
     """
     The cloud renderer provides the methods to display the cloud.
     It will adapt the cloud with a steamer to gets the things out.
     """
-    
+
     def Title(self):
         """
         Returns the name of a tagcloud
         """
-    
+
     def update_tags_tree(self):
         """
         This is the restricted access for a manager to handle his cloud.
@@ -219,7 +222,7 @@ class ICloudRenderer( Interface ):
         """
         default render method
         """
-        
+
     def getVaporizedCloud(self):
         """
         This method return as list of dictionnaries.
@@ -241,7 +244,7 @@ class ICloudRenderer( Interface ):
         The result is an iterable sequence of unicodes.
         """
 
-    def removableTags(self):        
+    def removableTags(self):
         """
         This method return the list of keywords actually selected.
         The result is an iterable sequence of dictionaries :
@@ -253,7 +256,7 @@ class ICloudRenderer( Interface ):
         """
         This method return the complete start path
         """
-    
+
     def getLinkPath(self):
         """
         This method calculates the link that will be used in the cloud HTML

--- a/collective/vaporisation/portlets/customizabletagcloudportlet.py
+++ b/collective/vaporisation/portlets/customizabletagcloudportlet.py
@@ -1,26 +1,30 @@
 from Acquisition import aq_parent
-from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from collective.vaporisation import logger
-from collective.vaporisation.events import TreeUpdateEvent
-from collective.vaporisation.interfaces import ICloudRenderer
-from collective.vaporisation.interfaces import ICustomizableCloud
-from collective.vaporisation.interfaces import ISearchLinkbase
-from collective.vaporisation.interfaces import ISteamer
-from collective.vaporisation.interfaces import IVaporizedCloud
-from plone.app.form.validators import null_validator
-from plone.app.form.widgets.uberselectionwidget import UberSelectionWidget
-from plone.app.portlets.portlets import base
-from plone.memoize import ram
-from time import time
-from zope.component._api import getAdapter
-from zope.event import notify
-from zope.formlib import form
-from zope.i18nmessageid import MessageFactory
-from zope.interface import implements
 
+from DateTime import DateTime
+
+from zope.formlib import form
+from zope.event import notify
+from zope.interface import implements
+from zope.component._api import getAdapter
+
+from plone.memoize import ram
+from plone.app.portlets.portlets import base
+from plone.app.form.validators import null_validator
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.CMFCore.utils import getToolByName
+
+from collective.vaporisation.interfaces import ISteamer, ICloudRenderer, \
+                                            IVaporizedCloud, ICustomizableCloud
+from collective.vaporisation.events import TreeUpdateEvent
+from collective.vaporisation import logger
+
+from zope.i18nmessageid import MessageFactory
 _ = MessageFactory('collective.vaporisation')
+
+from plone.app.form.widgets.uberselectionwidget import UberSelectionWidget
+
+from time import time
 
 
 def _cloud_key(method, self):
@@ -116,8 +120,7 @@ class Renderer(base.Renderer):
         super(Renderer, self).__init__(context, request, view, manager, data)
         self.subjects = None
         self.putils = getToolByName(context, 'plone_utils')
-        self.linkbase = ISearchLinkbase(self.context)
-        self.purl = self.linkbase.portlet_base_url()
+        self.purl = getToolByName(context, 'portal_url')()
         self.encoding = self.putils.getSiteEncoding()
         self.portal = self.context.portal_url.getPortalObject()
 
@@ -174,10 +177,9 @@ class Renderer(base.Renderer):
         removable = list()
 
         for tag in tags:
-            base_url = self.linkbase.removable_base_url()
-            query = 'cloud_search?portlet=%s&path=%s' % (self.data.__name__,
+            base_url = 'cloud_search?portlet=%s&path=%s' % (self.data.__name__,
                                                             search_path)
-            query = '%s/%s' % (base_url, query)
+            query = '%s/%s' % (self.context.absolute_url(), base_url)
             tag_url = '&tags:list=%s'
             tags_url = ''.join([tag_url % k
                                  for k in tags
@@ -212,7 +214,8 @@ class Renderer(base.Renderer):
                 portlet_path = '/'+self.portal.getId()+portlet_path
         else:
             portlet_path = '/'+self.portal.getId()
-        link = self.linkbase.linkpath_base_url()
+        portal = getToolByName(self.context, 'portal_url').getPortalObject()
+        link = "%s/cloud_search" % portal.absolute_url()
         portlet = self.request.form.get('portlet', None)
         query = self.request['QUERY_STRING']
         if query and portlet == self.data.__name__:

--- a/collective/vaporisation/profiles/default/portlets.xml
+++ b/collective/vaporisation/profiles/default/portlets.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0"?>
-<!-- This file is used to register new types of portlets. It can also
-     be used to register completely new column types. See CMFPlone's version
-     of this file for more information.
-  -->
 <portlets>
-
    <portlet
      addview="collective.vaporisation.tagcloud"
      title="Tagcloud portlet"
      description="A portlet that displays a cloud of tags to browser through"
    />
-
 </portlets>

--- a/collective/vaporisation/vocabularies.py
+++ b/collective/vaporisation/vocabularies.py
@@ -45,30 +45,41 @@ class KeywordVocabulary(object):
             indexes_to_use = ['Subject']
 
         if hasattr(context, 'startpath'):
-            root_path= ('/').join(context.portal_url.getPortalObject().getPhysicalPath())
+            root_path = ('/').join(
+                    context.portal_url.getPortalObject().getPhysicalPath())
             if context.startpath:
-                search_path= root_path + context.startpath
+                search_path = root_path + context.startpath
             else:
-                search_path= root_path
+                search_path = root_path
             if hasattr(context, 'type') and context.type:
                 for index in indexes_to_use:
-                     subjects = subjects + [x for x
-                                           in catalog.uniqueValuesFor(index)
-                                           if catalog.searchResults({'path':search_path,'portal_type':context.type,index:x})]
+                    subjects = subjects + [
+                        x for x in catalog.uniqueValuesFor(index)
+                        if catalog.searchResults({
+                            'path': search_path,
+                            'portal_type': context.type,
+                            index:x})]
             else:
                 for index in indexes_to_use:
-                    subjects = subjects + [x for x
-                                          in catalog.uniqueValuesFor(index)
-                                          if catalog.searchResults({'path':search_path,index:x})]
+                    subjects = subjects + [
+                        x for x
+                        in catalog.uniqueValuesFor(index)
+                        if catalog.searchResults({
+                            'path':search_path,
+                            index:x})]
         else:
             if hasattr(context, 'type') and context.type:
                 for index in indexes_to_use:
-                    subjects = subjects + [x for x
-                            in catalog.uniqueValuesFor(index)
-                            if catalog.searchResults({'portal_type':context.type,index:x})]
+                    subjects = subjects + [
+                        x for x
+                        in catalog.uniqueValuesFor(index)
+                        if catalog.searchResults({
+                            'portal_type':context.type,
+                            index:x})]
             else:
                 for index in indexes_to_use:
-                    subjects = subjects + [x for x in catalog.uniqueValuesFor(index)]
+                    subjects = subjects + [
+                        x for x in catalog.uniqueValuesFor(index)]
 
         keywords = set([unicode(k, encoding) for k in subjects])
         terms = [KeywordTerm(k) for k in sorted(keywords)]
@@ -84,11 +95,15 @@ class IndexesVocabulary(object):
 
     def __call__(self, context):
         pc = context.portal_catalog
-        remove_indexes = ['allowedRolesAndUsers','getRawRelatedItems','object_provides']
+        remove_indexes = [
+            'allowedRolesAndUsers',
+            'getRawRelatedItems',
+            'object_provides'
+        ]
         indexes = [x for x in pc.indexes()
-                   if pc._catalog.indexes[x].meta_type=='KeywordIndex'
+                   if pc._catalog.indexes[x].meta_type == 'KeywordIndex'
                    and not x in remove_indexes]
-        terms = [SimpleTerm(index,index) for index in indexes]
+        terms = [SimpleTerm(index, index) for index in indexes]
         return SimpleVocabulary(terms)
 
 IndexesVocabularyFactory = IndexesVocabulary()
@@ -103,7 +118,7 @@ class ModeVocabulary(object):
         encoders = [encoder[0]
                     for encoder
                     in getAdapters((pseudoassignment,), ISteamer)]
-        terms = [SimpleTerm(encoder,encoder) for encoder in encoders]
+        terms = [SimpleTerm(encoder, encoder) for encoder in encoders]
         return SimpleVocabulary(terms)
 
 ModeVocabularyFactory = ModeVocabulary()

--- a/collective/vaporisation/vocabularies.py
+++ b/collective/vaporisation/vocabularies.py
@@ -1,31 +1,29 @@
 # -*- coding: utf-8 -*-
-
 try:
     from zope.app.schema.vocabulary import IVocabularyFactory
 except ImportError:
     # Plone 4.1
     from zope.schema.interfaces import IVocabularyFactory
-
-from zope.interface.declarations import directlyProvides, implements
-from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 from Products.CMFCore.utils import getToolByName
-from zope.schema.interfaces import ITokenizedTerm, ITitledTokenizedTerm
-from zope.component._api import getAdapters
-from interfaces import ISteamer
 from collective.vaporisation.portlets import pseudoassignment
+from interfaces import ISteamer
+from zope.component._api import getAdapters
+from zope.interface.declarations import directlyProvides, implements
+from zope.schema.interfaces import ITokenizedTerm, ITitledTokenizedTerm
+from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 
 
 class KeywordTerm(object):
     """Simple tokenized keyword used by SimpleVocabulary."""
-    
+
     implements(ITokenizedTerm)
-    
+
     def __init__(self, value):
         """Create a term from the single value
         This class prevents the use of the silly bugged SimpleTerm.
         """
         self.value = value
-        self.token = value            
+        self.token = value
         self.title = value
         directlyProvides(self, ITitledTokenizedTerm)
 
@@ -33,19 +31,19 @@ class KeywordTerm(object):
 class KeywordVocabulary(object):
     """Vocabulary factory for keywords of a cloud.
     """
-    implements( IVocabularyFactory )
-    
+    implements(IVocabularyFactory)
+
     def __call__(self, context):
         catalog = getToolByName(context, 'portal_catalog')
         putils   = getToolByName(context, 'plone_utils')
         encoding = putils.getSiteEncoding()
         subjects = []
-        
+
         if hasattr(context, 'indexes_to_use'):
             indexes_to_use = context.indexes_to_use
         else:
             indexes_to_use = ['Subject']
-            
+
         if hasattr(context, 'startpath'):
             root_path= ('/').join(context.portal_url.getPortalObject().getPhysicalPath())
             if context.startpath:
@@ -55,24 +53,24 @@ class KeywordVocabulary(object):
             if hasattr(context, 'type') and context.type:
                 for index in indexes_to_use:
                      subjects = subjects + [x for x
-                                           in catalog.uniqueValuesFor(index) 
+                                           in catalog.uniqueValuesFor(index)
                                            if catalog.searchResults({'path':search_path,'portal_type':context.type,index:x})]
-            else:     
+            else:
                 for index in indexes_to_use:
-                    subjects = subjects + [x for x 
-                                          in catalog.uniqueValuesFor(index) 
+                    subjects = subjects + [x for x
+                                          in catalog.uniqueValuesFor(index)
                                           if catalog.searchResults({'path':search_path,index:x})]
         else:
             if hasattr(context, 'type') and context.type:
                 for index in indexes_to_use:
                     subjects = subjects + [x for x
-                            in catalog.uniqueValuesFor(index) 
+                            in catalog.uniqueValuesFor(index)
                             if catalog.searchResults({'portal_type':context.type,index:x})]
             else:
                 for index in indexes_to_use:
                     subjects = subjects + [x for x in catalog.uniqueValuesFor(index)]
-        
-        keywords = set([unicode(k, encoding) for k in subjects])        
+
+        keywords = set([unicode(k, encoding) for k in subjects])
         terms = [KeywordTerm(k) for k in sorted(keywords)]
         return SimpleVocabulary(terms)
 
@@ -82,7 +80,7 @@ KeywordVocabularyFactory = KeywordVocabulary()
 class TypesVocabulary(object):
     """Vocabulary factory for types of a cloud.
     """
-    implements( IVocabularyFactory )
+    implements(IVocabularyFactory)
 
     def __call__(self, context):
         portal_types = getToolByName(context, 'portal_types')
@@ -96,6 +94,7 @@ class TypesVocabulary(object):
 
 TypesVocabularyFactory = TypesVocabulary()
 
+
 class IndexesVocabulary(object):
     """Vocabulary factory for indexes of a cloud.
     """
@@ -104,13 +103,14 @@ class IndexesVocabulary(object):
     def __call__(self, context):
         pc = context.portal_catalog
         remove_indexes = ['allowedRolesAndUsers','getRawRelatedItems','object_provides']
-        indexes = [x for x in pc.indexes() 
-                   if pc._catalog.indexes[x].meta_type=='KeywordIndex' 
+        indexes = [x for x in pc.indexes()
+                   if pc._catalog.indexes[x].meta_type=='KeywordIndex'
                    and not x in remove_indexes]
         terms = [SimpleTerm(index,index) for index in indexes]
         return SimpleVocabulary(terms)
 
 IndexesVocabularyFactory = IndexesVocabulary()
+
 
 class ModeVocabulary(object):
     """Vocabulary factory for mode to use of a cloud.
@@ -118,11 +118,10 @@ class ModeVocabulary(object):
     implements( IVocabularyFactory )
 
     def __call__(self, context):
-        encoders = [encoder[0] 
-                    for encoder 
+        encoders = [encoder[0]
+                    for encoder
                     in getAdapters((pseudoassignment,), ISteamer)]
         terms = [SimpleTerm(encoder,encoder) for encoder in encoders]
         return SimpleVocabulary(terms)
 
 ModeVocabularyFactory = ModeVocabulary()
-

--- a/collective/vaporisation/vocabularies.py
+++ b/collective/vaporisation/vocabularies.py
@@ -77,28 +77,10 @@ class KeywordVocabulary(object):
 KeywordVocabularyFactory = KeywordVocabulary()
 
 
-class TypesVocabulary(object):
-    """Vocabulary factory for types of a cloud.
-    """
-    implements(IVocabularyFactory)
-
-    def __call__(self, context):
-        portal_types = getToolByName(context, 'portal_types')
-        portal_properties = getToolByName(context, 'portal_properties')
-        metaTypesNotToList = portal_properties.navtree_properties.metaTypesNotToList
-        types = [ x for x
-                 in portal_types.keys()
-                 if x not in metaTypesNotToList]
-        terms = [SimpleTerm(type,type) for type in types]
-        return SimpleVocabulary(terms)
-
-TypesVocabularyFactory = TypesVocabulary()
-
-
 class IndexesVocabulary(object):
     """Vocabulary factory for indexes of a cloud.
     """
-    implements( IVocabularyFactory )
+    implements(IVocabularyFactory)
 
     def __call__(self, context):
         pc = context.portal_catalog
@@ -115,7 +97,7 @@ IndexesVocabularyFactory = IndexesVocabulary()
 class ModeVocabulary(object):
     """Vocabulary factory for mode to use of a cloud.
     """
-    implements( IVocabularyFactory )
+    implements(IVocabularyFactory)
 
     def __call__(self, context):
         encoders = [encoder[0]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,10 +4,6 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
-- Introduce ISearchLinkbase adapter for configurable tagcloud links.
-  [thet]
-
-
 - For the types selection in portlet settings, use reallyuserfriendlytypes from
   plone.app.vocabularies instead own types vocabulary. Own vocabulary didn't
   return metaTypesNotToList.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,14 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce ISearchLinkbase adapter for configurable tagcloud links.
+  [thet]
+
+
+- For the types selection in portlet settings, use reallyuserfriendlytypes from
+  plone.app.vocabularies instead own types vocabulary. Own vocabulary didn't
+  return metaTypesNotToList.
+  [thet]
 
 
 1.3.6 (2012-12-07)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
+- In Steamers init method, provide a base_query and search_path attribute for
+  easier overriding in custom steamer classes, which derive from the default
+  one.
+  [thet]
+
 - For the types selection in portlet settings, use reallyuserfriendlytypes from
   plone.app.vocabularies instead own types vocabulary. Own vocabulary didn't
   return metaTypesNotToList.


### PR DESCRIPTION
collective.vaporisation.types doesn't display metaTypesNotToList - a list of types which should not displayed in navigation menus. in my point of view, i often want to build taglists from types, which are exactly not in the navigation menu - like events. there is a vocabulary, which fits better my usecase - and probably yours too? it's plone.app.vocabularies.ReallyUserFriendlyTypes

UPDATE:
In Steamers init method, provide a base_query and search_path attribute for easier overriding in custom steamer classes, which derive from the default one.

besides of that, some pep8 cleanups were done.
